### PR TITLE
chore: fix lint warnings in VAD, AEC, and stateless adapter

### DIFF
--- a/extensions/realtime-aec/src/browser-audio-driver.ts
+++ b/extensions/realtime-aec/src/browser-audio-driver.ts
@@ -150,23 +150,22 @@ export class BrowserAudioDriver implements AudioDriver {
     void this.ensureStarted().catch((err) =>
       log.error({ err: String(err) }, "ensureStarted (capture) failed"),
     );
-    const self = this;
     const stream: AsyncIterable<Buffer> = {
-      [Symbol.asyncIterator]() {
+      [Symbol.asyncIterator]: () => {
         return {
-          next(): Promise<IteratorResult<Buffer>> {
-            if (self.captureStopped) {
+          next: (): Promise<IteratorResult<Buffer>> => {
+            if (this.captureStopped) {
               return Promise.resolve({ value: undefined, done: true });
             }
-            const queued = self.captureBuf.shift();
+            const queued = this.captureBuf.shift();
             if (queued) {
               return Promise.resolve({ value: queued, done: false });
             }
             return new Promise<IteratorResult<Buffer>>((resolve) => {
-              self.capturePending.push({ resolve });
+              this.capturePending.push({ resolve });
             });
           },
-          return(): Promise<IteratorResult<Buffer>> {
+          return: (): Promise<IteratorResult<Buffer>> => {
             return Promise.resolve({ value: undefined, done: true });
           },
         };

--- a/packages/realtime/src/backend/stepfun-stateless.ts
+++ b/packages/realtime/src/backend/stepfun-stateless.ts
@@ -457,7 +457,7 @@ export class StepfunStatelessAdapter implements BackendAdapter {
     let msg: any;
     try {
       msg = JSON.parse(raw);
-    } catch (e) {
+    } catch {
       this.log.warn({ raw: raw.slice(0, 200) }, "non-json message");
       return;
     }

--- a/packages/realtime/src/vad/cli-handlers.ts
+++ b/packages/realtime/src/vad/cli-handlers.ts
@@ -113,9 +113,8 @@ function editDistance(a: string, b: string): number {
     bl = b.length;
   if (al === 0) return bl;
   if (bl === 0) return al;
-  let prev = new Array(bl + 1),
-    curr = new Array(bl + 1);
-  for (let j = 0; j <= bl; j++) prev[j] = j;
+  let prev = Array.from({ length: bl + 1 }, (_, j) => j),
+    curr = Array.from({ length: bl + 1 }, () => 0);
   for (let i = 1; i <= al; i++) {
     curr[0] = i;
     for (let j = 1; j <= bl; j++) {

--- a/packages/realtime/src/vad/resolver.ts
+++ b/packages/realtime/src/vad/resolver.ts
@@ -249,9 +249,8 @@ function editDistance(a: string, b: string): number {
   if (al === 0) return bl;
   if (bl === 0) return al;
 
-  let prev = new Array(bl + 1);
-  let curr = new Array(bl + 1);
-  for (let j = 0; j <= bl; j++) prev[j] = j;
+  let prev = Array.from({ length: bl + 1 }, (_, j) => j);
+  let curr = Array.from({ length: bl + 1 }, () => 0);
 
   for (let i = 1; i <= al; i++) {
     curr[0] = i;


### PR DESCRIPTION
Closes #62

## Why

`pnpm check` surfaced several low-risk `oxlint` warnings on a fresh checkout. This PR clears them.

Per `AGENTS.md` §7, `README.md`, `README_CN.md`, and `.gitignore` are currently frozen, so this PR touches **code only** — the markdown/`.gitignore` changes from the earlier revision have been dropped (and were already addressed on `main`).

## What changed

- **VAD edit-distance helpers** (`cli-handlers.ts`, `resolver.ts`): replace `new Array(length)` sparse-array construction with `Array.from`, avoiding holey arrays.
- **Stateless backend adapter** (`stepfun-stateless.ts`): drop the unused `catch (e)` binding.
- **Browser AEC async iterator** (`browser-audio-driver.ts`): use arrow functions to avoid `const self = this` aliasing.

## Verification

- `pnpm check` exits 0 (test + lint + dep-guard + deadcode + tsc + prettier) — `1475` tests pass.
- Rebased onto the latest `main`; no conflicts.
