### PR TITLE
Reject malformed numeric CLI options

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "endOfLine": "auto"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ Step Realtime CLI 采用分层 monorepo 架构，默认依赖方向如下：
 - `extensions/realtime-aec/`：基于 Chrome 的 AEC 适配
 - 其他第三方系统集成（IM / Email / storage / vector db / search backend 等）
 
-扩展目录只负责外部系统对接，不负责核心编排语义。realtime-* 系列适配器统一依赖 `packages/realtime` 暴露的协议层。
+扩展目录只负责外部系统对接，不负责核心编排语义。realtime-\* 系列适配器统一依赖 `packages/realtime` 暴露的协议层。
 
 ### `src/gateway/`
 
@@ -311,7 +311,7 @@ TUI / UI / CLI / Desktop 默认通过 `packages/sdk` 调用 gateway：
 - 新增 CLI 子命令注册：`src/commands/`
 - 新增本地 CLI / TUI 运行时装配：`src/runtime/`
 - 新增内置工具或技能：`skills/`
-- 新增第三方集成或通道（含 LLM / MCP / realtime-* 适配）：`extensions/`
+- 新增第三方集成或通道（含 LLM / MCP / realtime-\* 适配）：`extensions/`
 - 新增服务端宿主能力：`src/gateway/`
 - 新增默认 CLI 客户端实现：`src/cli/`
 - 新增界面与交互：`src/tui/`、`ui/`、`apps/*`

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@
 
 StepFun operates two independent sites; pick the one that matches where your API key was issued. The two sites do **not** share accounts or keys.
 
-| Region | Console | API endpoint | Installer |
-| --- | --- | --- | --- |
-| Mainland China (default) | https://platform.stepfun.com/ | `https://api.stepfun.com` | `bash scripts/setup.sh` |
-| Overseas | https://platform.stepfun.ai/ | `https://api.stepfun.ai` | `bash scripts/setup-overseas.sh` |
+| Region                   | Console                       | API endpoint              | Installer                        |
+| ------------------------ | ----------------------------- | ------------------------- | -------------------------------- |
+| Mainland China (default) | https://platform.stepfun.com/ | `https://api.stepfun.com` | `bash scripts/setup.sh`          |
+| Overseas                 | https://platform.stepfun.ai/  | `https://api.stepfun.ai`  | `bash scripts/setup-overseas.sh` |
 
 `scripts/setup-overseas.sh` runs the same flow as `scripts/setup.sh` and then rewrites `~/.step-cli/config.json` so both the realtime WebSocket and the models-proxy base URL point at `api.stepfun.ai`. All other flags (`--skip-build`, `--force-config`, `--uninstall`, …) are forwarded verbatim.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -30,10 +30,10 @@
 
 StepFun 提供两个相互独立的站点，请按 API Key 的发放来源选择对应安装方式。两个站点的账号与密钥**不互通**。
 
-| 站点 | 控制台 | API 域名 | 安装脚本 |
-| --- | --- | --- | --- |
-| 国内（默认） | https://platform.stepfun.com/ | `https://api.stepfun.com` | `bash scripts/setup.sh` |
-| 海外 | https://platform.stepfun.ai/ | `https://api.stepfun.ai` | `bash scripts/setup-overseas.sh` |
+| 站点         | 控制台                        | API 域名                  | 安装脚本                         |
+| ------------ | ----------------------------- | ------------------------- | -------------------------------- |
+| 国内（默认） | https://platform.stepfun.com/ | `https://api.stepfun.com` | `bash scripts/setup.sh`          |
+| 海外         | https://platform.stepfun.ai/  | `https://api.stepfun.ai`  | `bash scripts/setup-overseas.sh` |
 
 `scripts/setup-overseas.sh` 会先复用 `scripts/setup.sh` 的全部流程，再把 `~/.step-cli/config.json` 中实时语音的 WebSocket 端点与 models-proxy 基础地址改写为 `api.stepfun.ai`。所有其他参数（`--skip-build`、`--force-config`、`--uninstall` 等）均会原样转发。
 

--- a/src/commands/artifacts-command.ts
+++ b/src/commands/artifacts-command.ts
@@ -30,6 +30,7 @@ import {
   parseCommanderProgram,
 } from "./commander-utils.js";
 import { setStderrDevLogStorageRootDirectory } from "../runtime/stderr-dev-log.js";
+import { parseNonNegativeInt } from "./option-parsers.js";
 
 interface WriteTarget {
   write(chunk: string): unknown;
@@ -389,14 +390,6 @@ function parseHarnessKindOption(value: string): AgentHarnessKind {
   throw new InvalidArgumentError(
     "harness kind must be 'main', 'subagent', or 'teammate'",
   );
-}
-
-function parseNonNegativeInt(value: string): number {
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed < 0) {
-    throw new InvalidArgumentError("value must be a non-negative integer");
-  }
-  return parsed;
 }
 
 function writeJson(stdout: WriteTarget, value: unknown): void {

--- a/src/commands/option-parsers.ts
+++ b/src/commands/option-parsers.ts
@@ -14,9 +14,28 @@ import { MIN_ANTHROPIC_THINKING_BUDGET_TOKENS } from "../bootstrap/config/defaul
 
 export class InvalidArgumentError extends Error {}
 
+const DECIMAL_INTEGER_PATTERN = /^[+-]?\d+$/u;
+const DECIMAL_NUMBER_PATTERN = /^[+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?$/iu;
+
+function parseDecimalInteger(value: string): number {
+  const normalized = value.trim();
+  if (!DECIMAL_INTEGER_PATTERN.test(normalized)) {
+    return Number.NaN;
+  }
+  return Number(normalized);
+}
+
+function parseFiniteNumber(value: string): number {
+  const normalized = value.trim();
+  if (!DECIMAL_NUMBER_PATTERN.test(normalized)) {
+    return Number.NaN;
+  }
+  return Number(normalized);
+}
+
 export function parsePositiveInt(value: string): number {
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isInteger(parsed) || parsed <= 0) {
+  const parsed = parseDecimalInteger(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
     throw new Error(`Expected positive integer, got: ${value}`);
   }
   return parsed;
@@ -32,8 +51,8 @@ export function parseOperatingMode(value: string): AgentOperatingMode {
 }
 
 export function parseNonNegativeInt(value: string): number {
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isInteger(parsed) || parsed < 0) {
+  const parsed = parseDecimalInteger(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
     throw new Error(`Expected non-negative integer, got: ${value}`);
   }
   return parsed;
@@ -107,7 +126,7 @@ export function parseToolSearchIndexProfile(
 }
 
 export function parseNumber(value: string): number {
-  const parsed = Number.parseFloat(value);
+  const parsed = parseFiniteNumber(value);
   if (!Number.isFinite(parsed)) {
     throw new Error(`Expected number, got: ${value}`);
   }


### PR DESCRIPTION
## Summary
- Reject malformed numeric CLI inputs instead of accepting partial parseInt/parseFloat parses.
- Reuse the shared non-negative integer parser for `step artifacts list --limit`.
- Add Prettier end-of-line configuration and format existing Markdown check blockers so `pnpm check` passes on Windows checkouts.

## Verification
- `pnpm exec tsx -e "import { parsePositiveInt, parseNonNegativeInt, parseNumber } from './src/commands/option-parsers.ts'; ..."`
- `pnpm exec prettier --check src/commands/option-parsers.ts src/commands/artifacts-command.ts`
- `pnpm check`