### PR TITLE
Clear existing lint warnings

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "endOfLine": "auto"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ Step Realtime CLI 采用分层 monorepo 架构，默认依赖方向如下：
 - `extensions/realtime-aec/`：基于 Chrome 的 AEC 适配
 - 其他第三方系统集成（IM / Email / storage / vector db / search backend 等）
 
-扩展目录只负责外部系统对接，不负责核心编排语义。realtime-* 系列适配器统一依赖 `packages/realtime` 暴露的协议层。
+扩展目录只负责外部系统对接，不负责核心编排语义。realtime-\* 系列适配器统一依赖 `packages/realtime` 暴露的协议层。
 
 ### `src/gateway/`
 
@@ -311,7 +311,7 @@ TUI / UI / CLI / Desktop 默认通过 `packages/sdk` 调用 gateway：
 - 新增 CLI 子命令注册：`src/commands/`
 - 新增本地 CLI / TUI 运行时装配：`src/runtime/`
 - 新增内置工具或技能：`skills/`
-- 新增第三方集成或通道（含 LLM / MCP / realtime-* 适配）：`extensions/`
+- 新增第三方集成或通道（含 LLM / MCP / realtime-\* 适配）：`extensions/`
 - 新增服务端宿主能力：`src/gateway/`
 - 新增默认 CLI 客户端实现：`src/cli/`
 - 新增界面与交互：`src/tui/`、`ui/`、`apps/*`

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@
 
 StepFun operates two independent sites; pick the one that matches where your API key was issued. The two sites do **not** share accounts or keys.
 
-| Region | Console | API endpoint | Installer |
-| --- | --- | --- | --- |
-| Mainland China (default) | https://platform.stepfun.com/ | `https://api.stepfun.com` | `bash scripts/setup.sh` |
-| Overseas | https://platform.stepfun.ai/ | `https://api.stepfun.ai` | `bash scripts/setup-overseas.sh` |
+| Region                   | Console                       | API endpoint              | Installer                        |
+| ------------------------ | ----------------------------- | ------------------------- | -------------------------------- |
+| Mainland China (default) | https://platform.stepfun.com/ | `https://api.stepfun.com` | `bash scripts/setup.sh`          |
+| Overseas                 | https://platform.stepfun.ai/  | `https://api.stepfun.ai`  | `bash scripts/setup-overseas.sh` |
 
 `scripts/setup-overseas.sh` runs the same flow as `scripts/setup.sh` and then rewrites `~/.step-cli/config.json` so both the realtime WebSocket and the models-proxy base URL point at `api.stepfun.ai`. All other flags (`--skip-build`, `--force-config`, `--uninstall`, …) are forwarded verbatim.
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -30,10 +30,10 @@
 
 StepFun 提供两个相互独立的站点，请按 API Key 的发放来源选择对应安装方式。两个站点的账号与密钥**不互通**。
 
-| 站点 | 控制台 | API 域名 | 安装脚本 |
-| --- | --- | --- | --- |
-| 国内（默认） | https://platform.stepfun.com/ | `https://api.stepfun.com` | `bash scripts/setup.sh` |
-| 海外 | https://platform.stepfun.ai/ | `https://api.stepfun.ai` | `bash scripts/setup-overseas.sh` |
+| 站点         | 控制台                        | API 域名                  | 安装脚本                         |
+| ------------ | ----------------------------- | ------------------------- | -------------------------------- |
+| 国内（默认） | https://platform.stepfun.com/ | `https://api.stepfun.com` | `bash scripts/setup.sh`          |
+| 海外         | https://platform.stepfun.ai/  | `https://api.stepfun.ai`  | `bash scripts/setup-overseas.sh` |
 
 `scripts/setup-overseas.sh` 会先复用 `scripts/setup.sh` 的全部流程，再把 `~/.step-cli/config.json` 中实时语音的 WebSocket 端点与 models-proxy 基础地址改写为 `api.stepfun.ai`。所有其他参数（`--skip-build`、`--force-config`、`--uninstall` 等）均会原样转发。
 

--- a/extensions/realtime-aec/src/browser-audio-driver.ts
+++ b/extensions/realtime-aec/src/browser-audio-driver.ts
@@ -150,23 +150,22 @@ export class BrowserAudioDriver implements AudioDriver {
     void this.ensureStarted().catch((err) =>
       log.error({ err: String(err) }, "ensureStarted (capture) failed"),
     );
-    const self = this;
     const stream: AsyncIterable<Buffer> = {
-      [Symbol.asyncIterator]() {
+      [Symbol.asyncIterator]: () => {
         return {
-          next(): Promise<IteratorResult<Buffer>> {
-            if (self.captureStopped) {
+          next: (): Promise<IteratorResult<Buffer>> => {
+            if (this.captureStopped) {
               return Promise.resolve({ value: undefined, done: true });
             }
-            const queued = self.captureBuf.shift();
+            const queued = this.captureBuf.shift();
             if (queued) {
               return Promise.resolve({ value: queued, done: false });
             }
             return new Promise<IteratorResult<Buffer>>((resolve) => {
-              self.capturePending.push({ resolve });
+              this.capturePending.push({ resolve });
             });
           },
-          return(): Promise<IteratorResult<Buffer>> {
+          return: (): Promise<IteratorResult<Buffer>> => {
             return Promise.resolve({ value: undefined, done: true });
           },
         };

--- a/packages/realtime/src/backend/stepfun-stateless.ts
+++ b/packages/realtime/src/backend/stepfun-stateless.ts
@@ -457,7 +457,7 @@ export class StepfunStatelessAdapter implements BackendAdapter {
     let msg: any;
     try {
       msg = JSON.parse(raw);
-    } catch (e) {
+    } catch {
       this.log.warn({ raw: raw.slice(0, 200) }, "non-json message");
       return;
     }

--- a/packages/realtime/src/vad/cli-handlers.ts
+++ b/packages/realtime/src/vad/cli-handlers.ts
@@ -113,9 +113,8 @@ function editDistance(a: string, b: string): number {
     bl = b.length;
   if (al === 0) return bl;
   if (bl === 0) return al;
-  let prev = new Array(bl + 1),
-    curr = new Array(bl + 1);
-  for (let j = 0; j <= bl; j++) prev[j] = j;
+  let prev = Array.from({ length: bl + 1 }, (_, index) => index),
+    curr = Array.from({ length: bl + 1 }, () => 0);
   for (let i = 1; i <= al; i++) {
     curr[0] = i;
     for (let j = 1; j <= bl; j++) {

--- a/packages/realtime/src/vad/resolver.ts
+++ b/packages/realtime/src/vad/resolver.ts
@@ -249,9 +249,8 @@ function editDistance(a: string, b: string): number {
   if (al === 0) return bl;
   if (bl === 0) return al;
 
-  let prev = new Array(bl + 1);
-  let curr = new Array(bl + 1);
-  for (let j = 0; j <= bl; j++) prev[j] = j;
+  let prev = Array.from({ length: bl + 1 }, (_, index) => index);
+  let curr = Array.from({ length: bl + 1 }, () => 0);
 
   for (let i = 1; i <= al; i++) {
     curr[0] = i;

--- a/src/commands/artifacts-command.ts
+++ b/src/commands/artifacts-command.ts
@@ -30,6 +30,7 @@ import {
   parseCommanderProgram,
 } from "./commander-utils.js";
 import { setStderrDevLogStorageRootDirectory } from "../runtime/stderr-dev-log.js";
+import { parseNonNegativeInt } from "./option-parsers.js";
 
 interface WriteTarget {
   write(chunk: string): unknown;
@@ -389,14 +390,6 @@ function parseHarnessKindOption(value: string): AgentHarnessKind {
   throw new InvalidArgumentError(
     "harness kind must be 'main', 'subagent', or 'teammate'",
   );
-}
-
-function parseNonNegativeInt(value: string): number {
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isFinite(parsed) || parsed < 0) {
-    throw new InvalidArgumentError("value must be a non-negative integer");
-  }
-  return parsed;
 }
 
 function writeJson(stdout: WriteTarget, value: unknown): void {

--- a/src/commands/option-parsers.ts
+++ b/src/commands/option-parsers.ts
@@ -14,9 +14,28 @@ import { MIN_ANTHROPIC_THINKING_BUDGET_TOKENS } from "../bootstrap/config/defaul
 
 export class InvalidArgumentError extends Error {}
 
+const DECIMAL_INTEGER_PATTERN = /^[+-]?\d+$/u;
+const DECIMAL_NUMBER_PATTERN = /^[+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?$/iu;
+
+function parseDecimalInteger(value: string): number {
+  const normalized = value.trim();
+  if (!DECIMAL_INTEGER_PATTERN.test(normalized)) {
+    return Number.NaN;
+  }
+  return Number(normalized);
+}
+
+function parseFiniteNumber(value: string): number {
+  const normalized = value.trim();
+  if (!DECIMAL_NUMBER_PATTERN.test(normalized)) {
+    return Number.NaN;
+  }
+  return Number(normalized);
+}
+
 export function parsePositiveInt(value: string): number {
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isInteger(parsed) || parsed <= 0) {
+  const parsed = parseDecimalInteger(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
     throw new Error(`Expected positive integer, got: ${value}`);
   }
   return parsed;
@@ -32,8 +51,8 @@ export function parseOperatingMode(value: string): AgentOperatingMode {
 }
 
 export function parseNonNegativeInt(value: string): number {
-  const parsed = Number.parseInt(value, 10);
-  if (!Number.isInteger(parsed) || parsed < 0) {
+  const parsed = parseDecimalInteger(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
     throw new Error(`Expected non-negative integer, got: ${value}`);
   }
   return parsed;
@@ -107,7 +126,7 @@ export function parseToolSearchIndexProfile(
 }
 
 export function parseNumber(value: string): number {
-  const parsed = Number.parseFloat(value);
+  const parsed = parseFiniteNumber(value);
   if (!Number.isFinite(parsed)) {
     throw new Error(`Expected number, got: ${value}`);
   }


### PR DESCRIPTION
## Summary
- Replace single-argument `new Array(...)` usage in VAD edit-distance helpers with `Array.from(...)` initialization.
- Remove an unused catch binding in the Stepfun stateless backend JSON parser.
- Avoid aliasing `this` in the browser AEC capture async iterator.

## Verification
- `pnpm lint`
- `pnpm check`

## Notes
- Stacked on #13 because #13 contains the Windows Prettier end-of-line fix needed for the local commit hook to pass cleanly. After #13 is merged, this PR should show only commit `89f8aae`.