### PR TITLE
Fix smart compaction abort handling

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "endOfLine": "auto"
+}

--- a/packages/core/src/agent/agent-loop.ts
+++ b/packages/core/src/agent/agent-loop.ts
@@ -907,6 +907,9 @@ export class AgentLoop {
         });
       }
     } catch (error) {
+      if (this.signal?.aborted) {
+        throw interruptError(this.signal);
+      }
       // Compaction should never break the main loop.
       const message = `Smart compaction failed unexpectedly: ${shorten(toErrorMessage(error), 160)}`;
       this.memory.recordDecision(message);

--- a/packages/core/src/agent/conversation-memory.ts
+++ b/packages/core/src/agent/conversation-memory.ts
@@ -565,6 +565,7 @@ export class ConversationMemory {
     maxSummaryTokens?: number;
     signal?: AbortSignal;
   }): Promise<SmartCompactResult> {
+    throwIfAborted(input.signal);
     this.repairIncompleteToolCalls();
     this.microCompactToolMessages();
 
@@ -572,6 +573,7 @@ export class ConversationMemory {
     const promptTokensBefore = await this.measureProjectedPromptTokens(input, {
       windowed: true,
     });
+    throwIfAborted(input.signal);
     if (promptTokensBefore <= thresholds.softTriggerTokens) {
       this.lastCompactionDecision = {
         source: "smart",
@@ -631,6 +633,7 @@ export class ConversationMemory {
     );
 
     while (promptTokensAfter > targetTokens && iterations < maxPasses) {
+      throwIfAborted(input.signal);
       const plan = this.computeAutoCompactionRange(
         input.systemPrompt,
         retainTail,
@@ -656,10 +659,12 @@ export class ConversationMemory {
         promptTokensAfter = await this.measureProjectedPromptTokens(input, {
           windowed: true,
         });
+        throwIfAborted(input.signal);
         continue;
       }
 
       const applied = await this.applySmartCompactionRange(plan, input);
+      throwIfAborted(input.signal);
       iterations += 1;
       summarizedMessages += applied.summarizedMessages;
       fromIndex ??= applied.fromIndex;
@@ -671,6 +676,7 @@ export class ConversationMemory {
       promptTokensAfter = await this.measureProjectedPromptTokens(input, {
         windowed: true,
       });
+      throwIfAborted(input.signal);
     }
 
     const compacted = summarizedMessages > 0 || iterations > 0;
@@ -1660,6 +1666,7 @@ export class ConversationMemory {
     mode: "model" | "heuristic";
     error?: string;
   }> {
+    throwIfAborted(input.signal);
     const chunk = this.messages.slice(plan.from, plan.to);
     if (chunk.length === 0) {
       return {
@@ -1746,6 +1753,7 @@ export class ConversationMemory {
         max_tokens: maxTokens,
         signal: input.signal,
       });
+      throwIfAborted(input.signal);
 
       const message = completion.choices[0]?.message;
       const summaryText =
@@ -1785,6 +1793,7 @@ export class ConversationMemory {
         mode: "model",
       };
     } catch (error) {
+      throwIfAborted(input.signal);
       this.rememberCompactedUserMessages(chunk);
       this.mergeCheckpointFromMessages({
         messages: chunk,
@@ -2308,6 +2317,23 @@ function truncateTextToTokenBudget(input: {
   }
 
   return best;
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) {
+    return;
+  }
+
+  const reason = signal.reason;
+  if (reason instanceof Error) {
+    throw reason;
+  }
+
+  if (typeof reason === "string" && reason.trim().length > 0) {
+    throw new Error(reason);
+  }
+
+  throw new Error("Operation aborted.");
 }
 
 export function formatContextUsage(value: ContextUsage): string {


### PR DESCRIPTION
## Summary
- Preserve user interrupts during smart compaction instead of treating aborted summary requests as recoverable compaction failures.
- Stop `ConversationMemory` before it applies heuristic fallback or advances compaction state when the active `AbortSignal` has been cancelled.
- Re-throw aborted smart compaction work from `AgentLoop` so it follows the same interruption path as model requests and plugin hooks.
- Add a minimal Prettier end-of-line config and apply the existing markdown formatting changes needed for `pnpm check` to run cleanly on Windows.

## Problem
Smart compaction passes the active run signal into token counting and the model request used to summarize older context. Before this change, an abort raised during that summary request could be caught by `applySmartCompactionRange()` as if it were an ordinary model failure. The fallback path would then build a heuristic summary and mutate memory state, including `summarizedUntil` and compacted user-message memory, before the outer loop observed the interruption.

That makes cancellation less predictable: a run can be interrupted, but still leave behind compaction state from work that should have stopped. `runSmartCompaction()` also caught all compaction errors as unexpected compaction failures, so abort-related errors could be recorded as normal compaction failure actions instead of exiting through the normal interrupt path.

## Changes
- Added abort guards around the smart compaction entry point, async token-counting boundaries, compaction loop iterations, and the model-summary fallback path.
- Added a post-summary-request abort check before applying model-generated summary state.
- Kept the existing heuristic fallback for non-abort summary failures, so ordinary compaction resilience is unchanged.
- Updated `AgentLoop.runSmartCompaction()` to rethrow when the run signal is aborted before recording an unexpected compaction failure.
- Added `.prettierrc.json` with `endOfLine: auto` and formatted the existing markdown tables/escapes that were blocking the required check locally.

## Verification
- `pnpm check`
- `pnpm exec tsx -` with a focused smart compaction abort assertion: an aborted summary request exits without advancing `summarizedUntil` or adding compacted user messages.

## Notes
- `pnpm check` still prints the existing oxlint warnings and knip configuration hints, but exits successfully.