### PR TITLE
fix: make AEC step in setup.sh gracefully degrade when Chrome is missing

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -180,12 +180,15 @@ else
       if [[ "$SKIP_CHROME_INSTALL" != 1 ]]; then
         if command -v brew >/dev/null 2>&1; then
           info "Installing Google Chrome via Homebrew…"
-          brew install --cask google-chrome || warn "Chrome install failed — continuing without AEC"
-          if detect_chrome; then
-            ok "Chrome installed"
-            AEC_AVAILABLE=1
+          if brew install --cask google-chrome; then
+            if detect_chrome; then
+              ok "Chrome installed"
+              AEC_AVAILABLE=1
+            else
+              warn "Chrome install succeeded but binary not detected."
+            fi
           else
-            warn "Chrome install succeeded but binary not detected."
+            warn "Chrome install failed — continuing without AEC"
           fi
         else
           info "Homebrew not found. Install Chrome manually:"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -175,7 +175,7 @@ else
       if [[ "$SKIP_CHROME_INSTALL" != 1 ]]; then
         if command -v brew >/dev/null 2>&1; then
           info "Installing Google Chrome via Homebrew…"
-          brew install --cask google-chrome
+          brew install --cask google-chrome || warn "Chrome install failed — continuing without AEC"
           if detect_chrome; then
             ok "Chrome installed"
             AEC_AVAILABLE=1

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,7 +3,7 @@
 #   1) pnpm install (workspace deps, idempotent / fast if already installed)
 #   2) step config init (writes ~/.step-cli/config.json template if missing)
 #   3) Silero VAD   (avr-vad + onnxruntime-node, then write voice.defaults.vad=silero)
-#   4) AEC          (ensure Chrome/Chromium is available, then write voice.defaults.aec=true)
+#   4) AEC          (enable AEC if Chrome/Chromium is available; gracefully skip otherwise)
 #   5) Build        (pnpm build — workspace bundle in dist/)
 #   6) Launcher     (native binary when Bun exists; otherwise Node launcher)
 #   7) Install      (copy launcher + runtime tree to ~/.step-cli/bin/; append PATH block to shell rc)
@@ -16,7 +16,7 @@
 # Usage:
 #   bash scripts/setup.sh                         # works on a fresh clone, even without pnpm
 #   pnpm init:all                                 # equivalent, if pnpm is already on PATH
-#   bash scripts/setup.sh --skip-chrome-install   # don't auto brew-install Chrome
+#   bash scripts/setup.sh --skip-chrome-install   # don't auto brew-install Chrome (macOS only)
 #   bash scripts/setup.sh --skip-install          # skip the pnpm install step
 #   bash scripts/setup.sh --skip-build            # skip build (reuse existing dist/ or dist/bin/step)
 #   bash scripts/setup.sh --force-config          # overwrite existing config.json
@@ -162,41 +162,51 @@ detect_chrome() {
   return 1
 }
 
+AEC_AVAILABLE=0
 if detect_chrome; then
   ok "Chrome/Chromium found"
+  AEC_AVAILABLE=1
 else
-  warn "Chrome/Chromium not found — AEC needs it for libwebrtc APM"
+  warn "Chrome/Chromium not found — AEC will be disabled."
+  info "AEC requires Chrome/Chromium for libwebrtc APM."
+  info "To enable AEC later, install Chrome/Chromium and run: step aec on"
   case "$(uname -s)" in
     Darwin)
-      if [[ "$SKIP_CHROME_INSTALL" == 1 ]]; then
-        info "Skipping auto-install. Run:  brew install --cask google-chrome"
-        exit 1
+      if [[ "$SKIP_CHROME_INSTALL" != 1 ]]; then
+        if command -v brew >/dev/null 2>&1; then
+          info "Installing Google Chrome via Homebrew…"
+          brew install --cask google-chrome
+          if detect_chrome; then
+            ok "Chrome installed"
+            AEC_AVAILABLE=1
+          else
+            warn "Chrome install succeeded but binary not detected."
+          fi
+        else
+          info "Homebrew not found. Install Chrome manually:"
+          info "  brew install --cask google-chrome"
+        fi
+      else
+        info "Skipping auto-install (--skip-chrome-install). Run:"
+        info "  brew install --cask google-chrome"
       fi
-      if ! command -v brew >/dev/null 2>&1; then
-        err "Homebrew not found. Install brew from https://brew.sh, then re-run."
-        exit 1
-      fi
-      info "Installing Google Chrome via Homebrew…"
-      brew install --cask google-chrome
-      ok "Chrome installed"
       ;;
     Linux)
       info "Install Chrome/Chromium with your package manager, e.g.:"
       info "  sudo apt-get install -y google-chrome-stable    # Debian/Ubuntu"
       info "  sudo dnf install -y chromium                    # Fedora"
-      info "Then re-run:  bash scripts/setup.sh"
-      exit 1
-      ;;
-    *)
-      err "Unsupported platform: $(uname -s)"
-      exit 1
       ;;
   esac
 fi
 
-step_cli aec on
-step_cli aec status
-ok "AEC enabled (voice.defaults.aec = true)"
+if [[ "$AEC_AVAILABLE" == 1 ]]; then
+  step_cli aec on
+  step_cli aec status
+  ok "AEC enabled (voice.defaults.aec = true)"
+else
+  step_cli aec off
+  ok "AEC skipped (Chrome not found; setup continues without echo cancellation)"
+fi
 
 # ── 5. Build production bundle ────────────────────────────────────────────
 bold "[5/7] Building production bundle"

--- a/scripts/setup.test.ts
+++ b/scripts/setup.test.ts
@@ -89,6 +89,18 @@ describe("scripts/setup.sh", () => {
     );
   });
 
+  it("isolates macOS Chrome paths in its test fixture", () => {
+    const { root } = createTestEnvironment();
+    const fixture = readFileSync(join(root, "scripts", "setup.sh"), "utf8");
+
+    expect(fixture).not.toContain(
+      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    );
+    expect(fixture).not.toContain(
+      "/Applications/Chromium.app/Contents/MacOS/Chromium",
+    );
+  });
+
   it.skipIf(process.platform === "win32")(
     "continues with AEC disabled when Homebrew cannot install Chrome",
     () => {
@@ -97,11 +109,11 @@ describe("scripts/setup.sh", () => {
         cwd: root,
         encoding: "utf8",
         env: {
-          ...process.env,
           HOME: home,
           PATH: `${join(root, "bin")}:/usr/bin:/bin`,
           SETUP_TEST_LOG: log,
           SHELL: "/bin/bash",
+          STEP_CHROME_PATH: "",
         },
       });
 

--- a/scripts/setup.test.ts
+++ b/scripts/setup.test.ts
@@ -23,19 +23,13 @@ function createExecutable(
   chmodSync(path, 0o755);
 }
 
-function copySetupScript(root: string, scripts: string): void {
+function copySetupScript(scripts: string): void {
   const source = join(process.cwd(), "scripts", "setup.sh");
   const target = join(scripts, "setup.sh");
-  const unavailableChrome = join(root, "unavailable-chrome");
-  const script = readFileSync(source, "utf8")
-    .replace(
-      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-      unavailableChrome,
-    )
-    .replace(
-      "/Applications/Chromium.app/Contents/MacOS/Chromium",
-      unavailableChrome,
-    );
+  const script = readFileSync(source, "utf8").replace(
+    "AEC_AVAILABLE=0",
+    "detect_chrome() { return 1; }\n\nAEC_AVAILABLE=0",
+  );
 
   writeFileSync(target, script, "utf8");
 }
@@ -50,7 +44,7 @@ function createTestEnvironment(): { home: string; log: string; root: string } {
   mkdirSync(scripts, { recursive: true });
   mkdirSync(bin);
   mkdirSync(home);
-  copySetupScript(root, scripts);
+  copySetupScript(scripts);
 
   createExecutable(bin, "uname", "#!/usr/bin/env bash\necho Darwin\n");
   createExecutable(
@@ -89,16 +83,11 @@ describe("scripts/setup.sh", () => {
     );
   });
 
-  it("isolates macOS Chrome paths in its test fixture", () => {
+  it("forces Chrome detection to fail in its test fixture", () => {
     const { root } = createTestEnvironment();
     const fixture = readFileSync(join(root, "scripts", "setup.sh"), "utf8");
 
-    expect(fixture).not.toContain(
-      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
-    );
-    expect(fixture).not.toContain(
-      "/Applications/Chromium.app/Contents/MacOS/Chromium",
-    );
+    expect(fixture).toContain("detect_chrome() { return 1; }");
   });
 
   it.skipIf(process.platform === "win32")(

--- a/scripts/setup.test.ts
+++ b/scripts/setup.test.ts
@@ -1,0 +1,98 @@
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const temporaryDirectories: string[] = [];
+
+function createExecutable(
+  directory: string,
+  name: string,
+  contents: string,
+): void {
+  const path = join(directory, name);
+  writeFileSync(path, contents, "utf8");
+  chmodSync(path, 0o755);
+}
+
+function createTestEnvironment(): { home: string; log: string; root: string } {
+  const root = mkdtempSync(join(tmpdir(), "step-setup-test-"));
+  const scripts = join(root, "scripts");
+  const bin = join(root, "bin");
+  const home = join(root, "home");
+  const log = join(root, "commands.log");
+  temporaryDirectories.push(root);
+  mkdirSync(scripts, { recursive: true });
+  mkdirSync(bin);
+  mkdirSync(home);
+  copyFileSync(
+    join(process.cwd(), "scripts", "setup.sh"),
+    join(scripts, "setup.sh"),
+  );
+
+  createExecutable(bin, "uname", "#!/usr/bin/env bash\necho Darwin\n");
+  createExecutable(bin, "brew", "#!/usr/bin/env bash\nexit 1\n");
+  createExecutable(
+    bin,
+    "pnpm",
+    '#!/usr/bin/env bash\nprintf \'pnpm %s\\n\' "$*" >> "$SETUP_TEST_LOG"\n',
+  );
+  createExecutable(
+    bin,
+    "node",
+    '#!/usr/bin/env bash\nprintf \'node %s\\n\' "$*" >> "$SETUP_TEST_LOG"\necho 1.0.0\n',
+  );
+  return { home, log, root };
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { force: true, recursive: true });
+  }
+});
+
+describe("scripts/setup.sh", () => {
+  it("handles a failed Homebrew Chrome install without exiting", () => {
+    const script = readFileSync(
+      join(process.cwd(), "scripts", "setup.sh"),
+      "utf8",
+    );
+
+    expect(script).toContain(
+      'brew install --cask google-chrome || warn "Chrome install failed — continuing without AEC"',
+    );
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "continues with AEC disabled when Homebrew cannot install Chrome",
+    () => {
+      const { home, log, root } = createTestEnvironment();
+      const result = execFileSync("bash", ["scripts/setup.sh"], {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          HOME: home,
+          PATH: `${join(root, "bin")}:/usr/bin:/bin`,
+          SETUP_TEST_LOG: log,
+          SHELL: "/bin/bash",
+        },
+      });
+
+      expect(result).toContain("[7/7] Installing");
+      expect(result).toContain("AEC skipped");
+      expect(readFileSync(log, "utf8")).toContain(
+        "node scripts/run-step.mjs --stale-only aec off",
+      );
+    },
+  );
+});

--- a/scripts/setup.test.ts
+++ b/scripts/setup.test.ts
@@ -78,8 +78,9 @@ describe("scripts/setup.sh", () => {
       "utf8",
     );
 
+    expect(script).toContain("if brew install --cask google-chrome; then");
     expect(script).toContain(
-      'brew install --cask google-chrome || warn "Chrome install failed — continuing without AEC"',
+      'warn "Chrome install failed — continuing without AEC"',
     );
   });
 

--- a/scripts/setup.test.ts
+++ b/scripts/setup.test.ts
@@ -1,7 +1,6 @@
 import { execFileSync } from "node:child_process";
 import {
   chmodSync,
-  copyFileSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -24,6 +23,23 @@ function createExecutable(
   chmodSync(path, 0o755);
 }
 
+function copySetupScript(root: string, scripts: string): void {
+  const source = join(process.cwd(), "scripts", "setup.sh");
+  const target = join(scripts, "setup.sh");
+  const unavailableChrome = join(root, "unavailable-chrome");
+  const script = readFileSync(source, "utf8")
+    .replace(
+      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+      unavailableChrome,
+    )
+    .replace(
+      "/Applications/Chromium.app/Contents/MacOS/Chromium",
+      unavailableChrome,
+    );
+
+  writeFileSync(target, script, "utf8");
+}
+
 function createTestEnvironment(): { home: string; log: string; root: string } {
   const root = mkdtempSync(join(tmpdir(), "step-setup-test-"));
   const scripts = join(root, "scripts");
@@ -34,13 +50,14 @@ function createTestEnvironment(): { home: string; log: string; root: string } {
   mkdirSync(scripts, { recursive: true });
   mkdirSync(bin);
   mkdirSync(home);
-  copyFileSync(
-    join(process.cwd(), "scripts", "setup.sh"),
-    join(scripts, "setup.sh"),
-  );
+  copySetupScript(root, scripts);
 
   createExecutable(bin, "uname", "#!/usr/bin/env bash\necho Darwin\n");
-  createExecutable(bin, "brew", "#!/usr/bin/env bash\nexit 1\n");
+  createExecutable(
+    bin,
+    "brew",
+    '#!/usr/bin/env bash\nprintf \'brew %s\\n\' "$*" >> "$SETUP_TEST_LOG"\nexit 1\n',
+  );
   createExecutable(
     bin,
     "pnpm",
@@ -90,7 +107,9 @@ describe("scripts/setup.sh", () => {
 
       expect(result).toContain("[7/7] Installing");
       expect(result).toContain("AEC skipped");
-      expect(readFileSync(log, "utf8")).toContain(
+      const commands = readFileSync(log, "utf8");
+      expect(commands).toContain("brew install --cask google-chrome");
+      expect(commands).toContain(
         "node scripts/run-step.mjs --stale-only aec off",
       );
     },


### PR DESCRIPTION
## Summary

Closes #26

`setup.sh` previously treated missing Chrome/Chromium as a fatal error at step [4/7] AEC, calling `exit 1` and aborting the entire installation. This blocked steps 5-7 (build, launcher, install) from running, making it impossible to install `step` on:

- Headless Linux servers without Chrome
- CI/Docker environments
- Any system where Chrome is not installed, even if the user only needs text mode (`step exec`)

Additionally, the `--skip-chrome-install` flag was only checked on macOS and completely ignored on Linux.

## Changes

- **Graceful degradation**: When Chrome is not found, the AEC step now warns the user and runs `step aec off` instead of aborting. The setup continues normally through build, launcher, and install.
- **macOS auto-install preserved**: On macOS without `--skip-chrome-install`, the script still attempts `brew install --cask google-chrome`, but no longer aborts if Homebrew is missing or the install fails.
- **Platform-specific guidance**: Shows install instructions for the detected OS so users can enable AEC later with `step aec on`.
- **Updated header comment**: The step 4 description now reflects the new behavior ("gracefully skip otherwise").

## Before / After

| Scenario | Before | After |
|---|---|---|
| Linux, no Chrome | `exit 1` at step 4 — setup aborted | Warns, runs `step aec off`, continues |
| Linux, no Chrome, `--skip-chrome-install` | `exit 1` at step 4 (flag ignored) | Same as above (flag is macOS-only) |
| macOS, no Chrome, `--skip-chrome-install` | `exit 1` at step 4 | Warns, runs `step aec off`, continues |
| macOS, no Chrome, no Homebrew | `exit 1` at step 4 | Warns, runs `step aec off`, continues |
| Chrome present (any OS) | `step aec on` ✓ | `step aec on` ✓ (unchanged) |

## Test plan

- [ ] Run `bash scripts/setup.sh` on Linux **without** Chrome — verify setup completes and `step --version` works
- [ ] Run `bash scripts/setup.sh` on Linux **with** Chrome — verify AEC is enabled
- [ ] Run `bash scripts/setup.sh --skip-chrome-install` on macOS without Chrome — verify setup completes with AEC disabled
- [ ] Run `bash scripts/setup.sh` on macOS without Chrome (with Homebrew) — verify Chrome auto-install is attempted, AEC enabled on success
