### PR TITLE
fix(build): emit OpenTUI runtime chunk and build agent-sdk

### DIFF
--- a/scripts/build-packages.mjs
+++ b/scripts/build-packages.mjs
@@ -29,6 +29,10 @@ const buildTargets = [
     dirPath: "packages/core",
   },
   {
+    name: "@step-cli/agent-sdk",
+    dirPath: "packages/agent-sdk",
+  },
+  {
     name: "@step-cli/sdk",
     dirPath: "packages/sdk",
   },

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   entry: {
     index: "src/index.ts",
     core: "packages/core/src/index.ts",
+    "runtime/local-tui-app": "src/runtime/local-tui-app.ts",
     "runtime/local-opentui-entry": "src/runtime/local-opentui-entry.tsx",
   },
   noExternal: [/^@step-cli\//],


### PR DESCRIPTION
Closes #25

## Problem

After running `bash scripts/setup.sh` and then `step`, the process exits immediately with:

```
step-cli error: OpenTUI runtime did not export createLocalTuiClientApp()
```

This is especially visible on WSL and other environments where the bundled OpenTUI chunk ends up empty.

## Root cause

Two separate build issues:

1. `tsdown` / `rolldown 1.0.0-beta.7` code-splits `src/runtime/local-tui-app.ts` into `dist/local-tui-app-<hash>.js`, but the resulting chunk is effectively empty (only imports) and does not export `createLocalTuiClientApp` or the `LocalStepCliTuiApp` class.
2. `extensions/realtime-voice/src/bridge/coding-bridge.ts` imports `@step-cli/agent-sdk`, but `scripts/build-packages.mjs` never builds `packages/agent-sdk`, so its `dist/index.js` is missing and the bundler treats it as external.

## Changes

- `tsdown.config.ts`: add `runtime/local-tui-app` as an explicit entry point, which forces the bundler to emit a real chunk with the required exports.
- `scripts/build-packages.mjs`: add `@step-cli/agent-sdk` to the package build targets.

## Verification

- `pnpm build` completes successfully.
- `node bin/step-cli.js --version` works using the built `dist/index.js`.
- `dist/runtime/local-tui-app.js` now contains `createLocalTuiClientApp` and `LocalStepCliTuiApp`.
- `packages/agent-sdk/dist/index.js` is now produced.

## Manual test plan

```bash
bash scripts/setup.sh
# open a new shell
step --version
step voice
```

**Note on runtime:** `step voice` (OpenTUI) requires Bun. If the installed launcher falls back to Node, or if a Windows Bun is picked up under WSL, you may hit the runtime errors described in #29. The installer fix in #37 ensures a Linux-native Bun is selected on WSL and a native binary is installed.

## Related

- #29 (Node.js runtime incompatibility with OpenTUI)
- #36 (installer WSL Bun detection issue)
- #37 (installer WSL Bun detection PR)
- #38 (unrelated Prettier formatting fix)
- #65 (tool-call fold/unfold in TUI — depends on this build fix)
