### PR TITLE
fix(tui): hide plugin-injected system reminders from transcript

### DIFF
--- a/packages/core/src/agent/agent-loop.ts
+++ b/packages/core/src/agent/agent-loop.ts
@@ -946,7 +946,7 @@ export class AgentLoop {
     if (message.role === "user") {
       this.memory.addUser(content);
     } else {
-      this.memory.addSystem(content);
+      this.memory.addSystem(content, { hidden: message.hidden });
     }
   }
 

--- a/packages/core/src/agent/conversation-memory.test.ts
+++ b/packages/core/src/agent/conversation-memory.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import type { SystemMessage } from "@step-cli/protocol";
 import {
   ConversationMemory,
   type MemoryConfig,
@@ -99,6 +100,23 @@ describe("ConversationMemory", () => {
       const state = memory.exportState();
       expect(state.messages).toHaveLength(1);
       expect(state.messages[0]!.role).toBe("system");
+    });
+
+    it("preserves hidden flag through export/load round-trip", () => {
+      const memory = new ConversationMemory(makeConfig());
+      memory.addSystem("hidden instruction", { hidden: true });
+      memory.addSystem("visible instruction");
+
+      const exported = memory.exportState();
+      const memory2 = new ConversationMemory(makeConfig());
+      memory2.loadState(exported);
+
+      const restored = memory2.exportState();
+      expect(restored.messages).toHaveLength(2);
+      expect(restored.messages[0]!.role).toBe("system");
+      expect((restored.messages[0]! as SystemMessage).hidden).toBe(true);
+      expect(restored.messages[1]!.role).toBe("system");
+      expect((restored.messages[1]! as SystemMessage).hidden).toBeUndefined();
     });
   });
 

--- a/packages/core/src/agent/conversation-memory.ts
+++ b/packages/core/src/agent/conversation-memory.ts
@@ -356,8 +356,12 @@ export class ConversationMemory {
     this.invalidateContextAssemblyForTranscriptMutation();
   }
 
-  addSystem(content: string): void {
-    this.messages.push({ role: "system", content });
+  addSystem(content: string, options?: { hidden?: boolean }): void {
+    this.messages.push({
+      role: "system",
+      content,
+      ...(options?.hidden ? { hidden: true } : undefined),
+    });
     this.invalidateContextAssemblyForTranscriptMutation();
     const normalized = shortenLine(content, this.config.decisionEntryMaxChars);
     if (normalized.length > 0) {
@@ -2048,6 +2052,7 @@ function cloneChatMessage(message: ChatMessage): ChatMessage {
     return {
       role: "system",
       content: message.content,
+      ...(message.hidden ? { hidden: true } : undefined),
     };
   }
 

--- a/packages/core/src/plugins/manager.ts
+++ b/packages/core/src/plugins/manager.ts
@@ -208,11 +208,15 @@ export class PluginManager {
           strategy: "head_tail",
         });
 
-        injected.push({
-          role: message.role,
-          content: truncated.text,
-          ...(message.hidden ? { hidden: true } : undefined),
-        });
+        injected.push(
+          message.role === "system"
+            ? {
+                role: "system",
+                content: truncated.text,
+                ...(message.hidden ? { hidden: true } : undefined),
+              }
+            : { role: "user", content: truncated.text },
+        );
       }
 
       if (injected.length >= MAX_TOTAL_INJECTED_MESSAGES) {

--- a/packages/core/src/plugins/manager.ts
+++ b/packages/core/src/plugins/manager.ts
@@ -211,6 +211,7 @@ export class PluginManager {
         injected.push({
           role: message.role,
           content: truncated.text,
+          ...(message.hidden ? { hidden: true } : undefined),
         });
       }
 

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -30,12 +30,21 @@ export interface PluginUserMessage {
   content: string;
 }
 
-export type PluginInjectedMessage = {
-  role: "system" | "user";
-  content: string;
-  /** When true, the message is only for the model context and should not be rendered in the UI. */
-  hidden?: boolean;
-};
+export type PluginInjectedMessage =
+  | {
+      role: "system";
+      content: string;
+      /**
+       * When true, the message is only for the model context and should not
+       * be rendered in the UI. Only system messages support this flag; the
+       * agent loop stores injected user messages without it.
+       */
+      hidden?: boolean;
+    }
+  | {
+      role: "user";
+      content: string;
+    };
 
 export interface PluginHookContext {
   workspaceRoot: string;

--- a/packages/core/src/plugins/types.ts
+++ b/packages/core/src/plugins/types.ts
@@ -33,6 +33,8 @@ export interface PluginUserMessage {
 export type PluginInjectedMessage = {
   role: "system" | "user";
   content: string;
+  /** When true, the message is only for the model context and should not be rendered in the UI. */
+  hidden?: boolean;
 };
 
 export interface PluginHookContext {

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -39,6 +39,8 @@ export interface JsonSchema {
 export interface SystemMessage {
   role: "system";
   content: string;
+  /** Internal messages injected by plugins; should not be rendered in the UI. */
+  hidden?: boolean;
 }
 
 export type UserAttachmentSource =

--- a/skills/builtin/src/plan-plugin.ts
+++ b/skills/builtin/src/plan-plugin.ts
@@ -135,6 +135,7 @@ export function createPlanPlugin(manager: PlanManager): ToolPlugin {
             {
               role: "system",
               content: renderPlanInjectedMessage(snapshot),
+              hidden: true,
             },
           ],
         };

--- a/skills/builtin/src/skill-plugin.ts
+++ b/skills/builtin/src/skill-plugin.ts
@@ -103,6 +103,7 @@ export function createSkillPlugin(
                 {
                   role: "system" as const,
                   content: renderInjectedSkills(injectedContents),
+                  hidden: true,
                 },
               ]
             : undefined;

--- a/skills/builtin/src/subagent-plugin.ts
+++ b/skills/builtin/src/subagent-plugin.ts
@@ -1268,6 +1268,7 @@ class BackgroundSubtaskManager {
       messages.push({
         role: "system",
         content: MAIN_ORCHESTRATION_REMINDER,
+        hidden: true,
       });
     }
 

--- a/src/runtime/local-opentui-bridge.ts
+++ b/src/runtime/local-opentui-bridge.ts
@@ -90,7 +90,7 @@ export class LocalOpenTuiTranscriptBridge implements StepCliTuiTranscriptControl
     return [
       ...this.sessionEntries,
       ...this.localEntries.map(stripLocalTranscriptEntry),
-    ];
+    ].filter((entry) => !entry.hidden);
   }
 
   subscribe(
@@ -900,6 +900,7 @@ function mapChatMessageToTranscriptEntry(
         role: "system",
         caption: null,
         content: message.content,
+        hidden: message.hidden,
       };
   }
 }

--- a/src/tui/app.tsx
+++ b/src/tui/app.tsx
@@ -1914,21 +1914,23 @@ function buildTranscriptItems(
 ): TranscriptItem[] {
   return [
     buildWelcomeTranscriptItem(width),
-    ...entries.map((entry, index) => {
-      const identity = resolveTranscriptIdentity(entry);
-      const body = compactToolTranscriptContent(entry);
-      const lines = wrapMultiline(body, Math.max(12, width - 4));
-      return {
-        id:
-          entry.id ||
-          `message:${index}:${identity.badge}:${identity.caption ?? ""}`,
-        ...identity,
-        backgroundColor: resolveTranscriptBackground(entry, theme),
-        border: false,
-        lines,
-        truncated: false,
-      };
-    }),
+    ...entries
+      .filter((entry) => !entry.hidden)
+      .map((entry, index) => {
+        const identity = resolveTranscriptIdentity(entry);
+        const body = compactToolTranscriptContent(entry);
+        const lines = wrapMultiline(body, Math.max(12, width - 4));
+        return {
+          id:
+            entry.id ||
+            `message:${index}:${identity.badge}:${identity.caption ?? ""}`,
+          ...identity,
+          backgroundColor: resolveTranscriptBackground(entry, theme),
+          border: false,
+          lines,
+          truncated: false,
+        };
+      }),
   ];
 }
 

--- a/src/tui/transcript-export.ts
+++ b/src/tui/transcript-export.ts
@@ -4,6 +4,7 @@ export function buildTranscriptClipboardText(
   entries: readonly StepCliTuiTranscriptEntry[],
 ): string {
   return entries
+    .filter((entry) => !entry.hidden)
     .map((entry) => formatTranscriptClipboardBlock(entry))
     .filter((block) => block.length > 0)
     .join("\n\n")

--- a/src/tui/types.ts
+++ b/src/tui/types.ts
@@ -87,6 +87,8 @@ export interface StepCliTuiTranscriptEntry {
   role: "assistant" | "user" | "tool" | "system";
   content: string;
   caption: string | null;
+  /** Internal message that should not be rendered in the transcript. */
+  hidden?: boolean;
 }
 
 export interface StepCliTuiQueuedTurnEntry {


### PR DESCRIPTION
Closes #33

## Problem

The `subagent-plugin` injects a `Delegation reminder` system message via `beforeModelRequest` on every user turn. Because the TUI renders every system message, the reminder appears repeatedly in the conversation transcript, cluttering the UI. Plan-plugin and skill-plugin inject similar internal status messages that also leak into the transcript.

## Solution

Add an optional `hidden` flag to plugin-injected system messages. Hidden messages are still included in the model context (so behavior is unchanged), but they are skipped by the TUI transcript renderer and clipboard export.

## Changes

- `packages/protocol/src/index.ts`: add `hidden?: boolean` to `SystemMessage`.
- `packages/core/src/plugins/types.ts`: add `hidden?: boolean` to `PluginInjectedMessage`.
- `packages/core/src/plugins/manager.ts`: preserve the `hidden` flag when aggregating injected messages.
- `packages/core/src/agent/agent-loop.ts`: pass `hidden` from injected messages into memory.
- `packages/core/src/agent/conversation-memory.ts`: preserve `hidden` when cloning/restoring system messages so it survives checkpoints.
- `src/runtime/local-opentui-bridge.ts`: forward `hidden` to transcript entries.
- `src/tui/types.ts`: add `hidden?: boolean` to `StepCliTuiTranscriptEntry`.
- `src/tui/app.tsx`: filter hidden entries out of `buildTranscriptItems`.
- `src/tui/transcript-export.ts`: filter hidden entries from clipboard export.
- `skills/builtin/src/subagent-plugin.ts`: mark `MAIN_ORCHESTRATION_REMINDER` as `hidden: true`.
- `skills/builtin/src/plan-plugin.ts`: mark plan-status injection as `hidden: true`.
- `skills/builtin/src/skill-plugin.ts`: mark skill-context injection as `hidden: true`.

## Verification

- `pnpm exec tsc --noEmit` passes.
- `pnpm build` succeeds.
- `pnpm exec vitest run packages/core/src/agent/conversation-memory.test.ts packages/core/src/agent/conversation-memory-checkpoint.test.ts` passes (23/23).
- `pnpm check` passes after #38 (formatting fix) is applied; only pre-existing lint warnings remain.
- The TUI launches without errors and no longer renders repeated `SYSTEM Delegation reminder` / `Plan status` / `Skill context` blocks.

## Related

- #38 fixes the unrelated Prettier formatting warning in `docs/skills/pr-review-decision.md`.
