### PR TITLE
fix(setup): prefer Linux-native Bun on WSL and respect STEP_BUN_BIN

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -58,6 +58,40 @@ warn() { printf "  \033[33m! %s\033[0m\n" "$*"; }
 err()  { printf "  \033[31m✗ %s\033[0m\n" "$*"; }
 step_cli() { node scripts/run-step.mjs --stale-only "$@"; }
 
+# Resolve a usable Bun binary. On WSL, a Windows bun (under /mnt) cannot build
+# or run a working Linux native binary, so we explicitly look for a
+# Linux-native installation first.
+resolve_bun() {
+  if [[ -n "${STEP_BUN_BIN:-}" ]]; then
+    if [[ -x "$STEP_BUN_BIN" ]]; then
+      echo "$STEP_BUN_BIN"
+      return 0
+    fi
+    warn "STEP_BUN_BIN=$STEP_BUN_BIN is not executable; ignoring" >&2
+  fi
+
+  local bun_path
+  bun_path=$(command -v bun || true)
+  if [[ -n "$bun_path" && "$bun_path" != /mnt/* ]]; then
+    echo "$bun_path"
+    return 0
+  fi
+
+  if [[ -n "$bun_path" && "$bun_path" == /mnt/* ]]; then
+    warn "Detected Windows Bun at $bun_path; looking for a Linux-native Bun..." >&2
+  fi
+
+  for candidate in "$HOME/.bun/bin/bun" "/usr/local/bin/bun" "/opt/bun/bin/bun"; do
+    if [[ -x "$candidate" ]]; then
+      info "Using Linux-native Bun: $candidate" >&2
+      echo "$candidate"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
 # ── 0. pre-flight ─────────────────────────────────────────────────────────
 # pnpm may be missing on a fresh clone. Try to bootstrap it via corepack
 # (bundled with Node ≥ 16.10) before bailing out.
@@ -185,13 +219,16 @@ if [[ "$SKIP_BUILD" == 1 ]]; then
   if [[ -x "dist/bin/step" ]]; then
     INSTALL_NATIVE_BINARY=1
   fi
-elif command -v "${STEP_BUN_BIN:-bun}" >/dev/null 2>&1; then
-  info "Bun found; building native binary (dist/bin/step)."
-  pnpm build:bin
-  ok "dist/bin/step built"
-  INSTALL_NATIVE_BINARY=1
 else
-  warn "Bun not found; installing a Node-based launcher instead of a native binary."
+  BUN_PATH=$(resolve_bun || true)
+  if [[ -n "$BUN_PATH" ]]; then
+    info "Bun found; building native binary (dist/bin/step)."
+    STEP_BUN_BIN="$BUN_PATH" pnpm build:bin
+    ok "dist/bin/step built"
+    INSTALL_NATIVE_BINARY=1
+  else
+    warn "Bun not found; installing a Node-based launcher instead of a native binary."
+  fi
 fi
 
 # ── 7. Install to ~/.step-cli/bin/ + ensure PATH ──────────────────────────


### PR DESCRIPTION
Closes #36

## Problem

On WSL, `scripts/setup.sh` resolves `bun` via `command -v bun`. If the user also has a Windows Bun on `PATH` (common when Node/npm are installed on Windows), the path is under `/mnt/c/...`. Using that binary to run `pnpm build:bin` either fails to produce a working Linux executable or produces a Windows binary that cannot run in WSL. If no Bun is found, the installer falls back to a Node-based launcher, but OpenTUI is Bun-only and fails on Node.

## Changes

- Add `resolve_bun()` in `scripts/setup.sh` that:
  - Honors `STEP_BUN_BIN` when explicitly set.
  - Detects a Windows Bun (`/mnt/*`) and warns about it.
  - Prefers a Linux-native Bun from `$HOME/.bun/bin/bun`, `/usr/local/bin/bun`, or `/opt/bun/bin/bun`.
- Use `STEP_BUN_BIN="$BUN_PATH" pnpm build:bin` so the build always uses the resolved binary.

## Verification

- `bash -n scripts/setup.sh` passes.
- `pnpm check` passes (only pre-existing warnings).
- On a WSL system where `which bun` points to `/mnt/c/.../bun` but `~/.bun/bin/bun` is the Linux build:
  - `bash scripts/setup.sh` now picks `~/.bun/bin/bun`.
  - `dist/bin/step` is a working Linux binary.
  - `step --version` and `step --help` work.

## Related

- #25 (build chunk issue)
- #29 (Node.js runtime incompatibility with OpenTUI)
- #28 (build fix PR)
