### PR TITLE
test(utils): align path and shell tests with TESTING.md on Windows

### DIFF
--- a/packages/utils/src/path.test.ts
+++ b/packages/utils/src/path.test.ts
@@ -213,6 +213,8 @@ import {
   resolveWritablePathInWorkspace,
 } from "./path.js";
 
+const isWindows = process.platform === "win32";
+
 async function makeWorkspace(): Promise<string> {
   // Use realpath so macOS /var -> /private/var symlink does not confuse
   // workspace-containment checks.
@@ -232,62 +234,71 @@ describe("resolveExistingPathInWorkspace", () => {
     }
   });
 
-  it("resolves a symlink target that lives inside the workspace", async () => {
-    const root = await makeWorkspace();
-    try {
-      await fs.writeFile(path.join(root, "real.txt"), "data");
-      await fs.symlink(
-        path.join(root, "real.txt"),
-        path.join(root, "link.txt"),
-      );
-      const result = await resolveExistingPathInWorkspace(root, "link.txt");
-      // Returns the resolved real target.
-      expect(result).toBe(path.join(root, "real.txt"));
-    } finally {
-      await fs.rm(root, { recursive: true });
-    }
-  });
+  it.skipIf(isWindows)(
+    "resolves a symlink target that lives inside the workspace",
+    async () => {
+      const root = await makeWorkspace();
+      try {
+        await fs.writeFile(path.join(root, "real.txt"), "data");
+        await fs.symlink(
+          path.join(root, "real.txt"),
+          path.join(root, "link.txt"),
+        );
+        const result = await resolveExistingPathInWorkspace(root, "link.txt");
+        // Returns the resolved real target.
+        expect(result).toBe(path.join(root, "real.txt"));
+      } finally {
+        await fs.rm(root, { recursive: true });
+      }
+    },
+  );
 
-  it("throws when a symlink points outside the workspace", async () => {
-    const root = await makeWorkspace();
-    const outside = await makeWorkspace();
-    try {
-      await fs.writeFile(path.join(outside, "secret.txt"), "x");
-      await fs.symlink(
-        path.join(outside, "secret.txt"),
-        path.join(root, "escape.txt"),
-      );
-      await expect(
-        resolveExistingPathInWorkspace(root, "escape.txt"),
-      ).rejects.toThrow("Path escapes workspace root");
-    } finally {
-      await fs.rm(root, { recursive: true });
-      await fs.rm(outside, { recursive: true });
-    }
-  });
+  it.skipIf(isWindows)(
+    "throws when a symlink points outside the workspace",
+    async () => {
+      const root = await makeWorkspace();
+      const outside = await makeWorkspace();
+      try {
+        await fs.writeFile(path.join(outside, "secret.txt"), "x");
+        await fs.symlink(
+          path.join(outside, "secret.txt"),
+          path.join(root, "escape.txt"),
+        );
+        await expect(
+          resolveExistingPathInWorkspace(root, "escape.txt"),
+        ).rejects.toThrow("Path escapes workspace root");
+      } finally {
+        await fs.rm(root, { recursive: true });
+        await fs.rm(outside, { recursive: true });
+      }
+    },
+  );
 
-  it("throws when the symlink's parent dir escapes the workspace", async () => {
-    const root = await makeWorkspace();
-    const outside = await makeWorkspace();
-    try {
-      // 'sub' inside root is a symlink to an outside dir; addressing
-      // sub/inner.txt makes the symlink parent check fail.
-      await fs.mkdir(path.join(outside, "real-dir"));
-      await fs.writeFile(path.join(outside, "real-dir", "inner.txt"), "y");
-      await fs.symlink(
-        path.join(outside, "real-dir"),
-        path.join(root, "sub"),
-        "dir",
-      );
-      // 'sub' itself is a symlink whose realpath is outside.
-      await expect(resolveExistingPathInWorkspace(root, "sub")).rejects.toThrow(
-        "Path escapes workspace root",
-      );
-    } finally {
-      await fs.rm(root, { recursive: true });
-      await fs.rm(outside, { recursive: true });
-    }
-  });
+  it.skipIf(isWindows)(
+    "throws when the symlink's parent dir escapes the workspace",
+    async () => {
+      const root = await makeWorkspace();
+      const outside = await makeWorkspace();
+      try {
+        // 'sub' inside root is a symlink to an outside dir; addressing
+        // sub/inner.txt makes the symlink parent check fail.
+        await fs.mkdir(path.join(outside, "real-dir"));
+        await fs.writeFile(path.join(outside, "real-dir", "inner.txt"), "y");
+        await fs.symlink(
+          path.join(outside, "real-dir"),
+          path.join(root, "sub"),
+          "dir",
+        );
+        // 'sub' itself is a symlink whose realpath is outside.
+        await expect(
+          resolveExistingPathInWorkspace(root, "sub"),
+        ).rejects.toThrow("Path escapes workspace root");
+      } finally {
+        await fs.rm(root, { recursive: true });
+        await fs.rm(outside, { recursive: true });
+      }
+    },
+  );
 
   it("rejects for a non-existent path (ENOENT from realpath)", async () => {
     const root = await makeWorkspace();
@@ -302,26 +313,29 @@ describe("resolveExistingPathInWorkspace", () => {
 });
 
 describe("resolveAddressedExistingPathInWorkspace", () => {
-  it("returns the addressed (non-real) resolved path", async () => {
-    const root = await makeWorkspace();
-    try {
-      await fs.writeFile(path.join(root, "real.txt"), "data");
-      await fs.symlink(
-        path.join(root, "real.txt"),
-        path.join(root, "link.txt"),
-      );
-      const result = await resolveAddressedExistingPathInWorkspace(
-        root,
-        "link.txt",
-      );
-      // Unlike resolveExistingPathInWorkspace, returns the addressed link path.
-      expect(result).toBe(path.join(root, "link.txt"));
-    } finally {
-      await fs.rm(root, { recursive: true });
-    }
-  });
+  it.skipIf(isWindows)(
+    "returns the addressed (non-real) resolved path",
+    async () => {
+      const root = await makeWorkspace();
+      try {
+        await fs.writeFile(path.join(root, "real.txt"), "data");
+        await fs.symlink(
+          path.join(root, "real.txt"),
+          path.join(root, "link.txt"),
+        );
+        const result = await resolveAddressedExistingPathInWorkspace(
+          root,
+          "link.txt",
+        );
+        // Unlike resolveExistingPathInWorkspace, returns the addressed link path.
+        expect(result).toBe(path.join(root, "link.txt"));
+      } finally {
+        await fs.rm(root, { recursive: true });
+      }
+    },
+  );
 
-  it("throws when symlink escapes workspace", async () => {
+  it.skipIf(isWindows)("throws when symlink escapes workspace", async () => {
     const root = await makeWorkspace();
     const outside = await makeWorkspace();
     try {
@@ -341,23 +355,26 @@ describe("resolveAddressedExistingPathInWorkspace", () => {
 });
 
 describe("resolveAddressedPathEntryInWorkspace", () => {
-  it("returns the resolved path early for a symlink entry", async () => {
-    const root = await makeWorkspace();
-    try {
-      await fs.writeFile(path.join(root, "real.txt"), "data");
-      await fs.symlink(
-        path.join(root, "real.txt"),
-        path.join(root, "link.txt"),
-      );
-      const result = await resolveAddressedPathEntryInWorkspace(
-        root,
-        "link.txt",
-      );
-      expect(result).toBe(path.join(root, "link.txt"));
-    } finally {
-      await fs.rm(root, { recursive: true });
-    }
-  });
+  it.skipIf(isWindows)(
+    "returns the resolved path early for a symlink entry",
+    async () => {
+      const root = await makeWorkspace();
+      try {
+        await fs.writeFile(path.join(root, "real.txt"), "data");
+        await fs.symlink(
+          path.join(root, "real.txt"),
+          path.join(root, "link.txt"),
+        );
+        const result = await resolveAddressedPathEntryInWorkspace(
+          root,
+          "link.txt",
+        );
+        expect(result).toBe(path.join(root, "link.txt"));
+      } finally {
+        await fs.rm(root, { recursive: true });
+      }
+    },
+  );
 
   it("resolves a regular file entry and validates real path", async () => {
     const root = await makeWorkspace();
@@ -373,27 +390,30 @@ describe("resolveAddressedPathEntryInWorkspace", () => {
     }
   });
 
-  it("returns resolved symlink even if it escapes (parent check passes)", async () => {
-    const root = await makeWorkspace();
-    const outside = await makeWorkspace();
-    try {
-      await fs.writeFile(path.join(outside, "secret.txt"), "x");
-      // Symlink directly in root; its parent (root) is in the workspace, so the
-      // parent check passes and the symlink branch returns early.
-      await fs.symlink(
-        path.join(outside, "secret.txt"),
-        path.join(root, "link.txt"),
-      );
-      const result = await resolveAddressedPathEntryInWorkspace(
-        root,
-        "link.txt",
-      );
-      expect(result).toBe(path.join(root, "link.txt"));
-    } finally {
-      await fs.rm(root, { recursive: true });
-      await fs.rm(outside, { recursive: true });
-    }
-  });
+  it.skipIf(isWindows)(
+    "returns resolved symlink even if it escapes (parent check passes)",
+    async () => {
+      const root = await makeWorkspace();
+      const outside = await makeWorkspace();
+      try {
+        await fs.writeFile(path.join(outside, "secret.txt"), "x");
+        // Symlink directly in root; its parent (root) is in the workspace, so the
+        // parent check passes and the symlink branch returns early.
+        await fs.symlink(
+          path.join(outside, "secret.txt"),
+          path.join(root, "link.txt"),
+        );
+        const result = await resolveAddressedPathEntryInWorkspace(
+          root,
+          "link.txt",
+        );
+        expect(result).toBe(path.join(root, "link.txt"));
+      } finally {
+        await fs.rm(root, { recursive: true });
+        await fs.rm(outside, { recursive: true });
+      }
+    },
+  );
 });
 
 describe("resolveWritablePathInWorkspace", () => {
@@ -421,50 +441,59 @@ describe("resolveWritablePathInWorkspace", () => {
     }
   });
 
-  it("follows a symlinked parent dir to an existing location inside workspace", async () => {
-    const root = await makeWorkspace();
-    try {
-      await fs.mkdir(path.join(root, "actual"));
-      await fs.symlink(path.join(root, "actual"), path.join(root, "linkdir"));
-      const result = await resolveWritablePathInWorkspace(
-        root,
-        "linkdir/file.txt",
-      );
-      // Nearest existing path is the symlink's real target, then file.txt.
-      expect(result).toBe(path.join(root, "actual", "file.txt"));
-    } finally {
-      await fs.rm(root, { recursive: true });
-    }
-  });
+  it.skipIf(isWindows)(
+    "follows a symlinked parent dir to an existing location inside workspace",
+    async () => {
+      const root = await makeWorkspace();
+      try {
+        await fs.mkdir(path.join(root, "actual"));
+        await fs.symlink(path.join(root, "actual"), path.join(root, "linkdir"));
+        const result = await resolveWritablePathInWorkspace(
+          root,
+          "linkdir/file.txt",
+        );
+        // Nearest existing path is the symlink's real target, then file.txt.
+        expect(result).toBe(path.join(root, "actual", "file.txt"));
+      } finally {
+        await fs.rm(root, { recursive: true });
+      }
+    },
+  );
 
-  it("throws when the nearest existing ancestor escapes the workspace", async () => {
-    const root = await makeWorkspace();
-    const outside = await makeWorkspace();
-    try {
-      await fs.symlink(outside, path.join(root, "escape"), "dir");
-      await expect(
-        resolveWritablePathInWorkspace(root, "escape/child.txt"),
-      ).rejects.toThrow("Path escapes workspace root");
-    } finally {
-      await fs.rm(root, { recursive: true });
-      await fs.rm(outside, { recursive: true });
-    }
-  });
+  it.skipIf(isWindows)(
+    "throws when the nearest existing ancestor escapes the workspace",
+    async () => {
+      const root = await makeWorkspace();
+      const outside = await makeWorkspace();
+      try {
+        await fs.symlink(outside, path.join(root, "escape"), "dir");
+        await expect(
+          resolveWritablePathInWorkspace(root, "escape/child.txt"),
+        ).rejects.toThrow("Path escapes workspace root");
+      } finally {
+        await fs.rm(root, { recursive: true });
+        await fs.rm(outside, { recursive: true });
+      }
+    },
+  );
 
-  it("rethrows non-ENOENT errors from realpath (ELOOP cycle)", async () => {
-    const root = await makeWorkspace();
-    try {
-      // a -> b, b -> a: realpath fails with ELOOP, which is not ENOENT, so
-      // findNearestExistingPath rethrows it (covers the non-ENOENT branch).
-      await fs.symlink(path.join(root, "b"), path.join(root, "a"));
-      await fs.symlink(path.join(root, "a"), path.join(root, "b"));
-      await expect(
-        resolveWritablePathInWorkspace(root, "a/child.txt"),
-      ).rejects.toThrow(/ELOOP|Symlink cycle|escapes workspace/);
-    } finally {
-      await fs.rm(root, { recursive: true });
-    }
-  });
+  it.skipIf(isWindows)(
+    "rethrows non-ENOENT errors from realpath (ELOOP cycle)",
+    async () => {
+      const root = await makeWorkspace();
+      try {
+        // a -> b, b -> a: realpath fails with ELOOP, which is not ENOENT, so
+        // findNearestExistingPath rethrows it (covers the non-ENOENT branch).
+        await fs.symlink(path.join(root, "b"), path.join(root, "a"));
+        await fs.symlink(path.join(root, "a"), path.join(root, "b"));
+        await expect(
+          resolveWritablePathInWorkspace(root, "a/child.txt"),
+        ).rejects.toThrow(/ELOOP|Symlink cycle|escapes workspace/);
+      } finally {
+        await fs.rm(root, { recursive: true });
+      }
+    },
+  );
 
   it("resolves a path whose ancestor chain walks up to the workspace root", async () => {
     const root = await makeWorkspace();

--- a/packages/utils/src/shell.test.ts
+++ b/packages/utils/src/shell.test.ts
@@ -9,6 +9,10 @@ const BIG_LIMIT = 1_000_000;
 // ubuntu/macOS legs still exercise them (so coverage is unaffected).
 const isWindows = process.platform === "win32";
 
+// Cross-platform long-running child for timeout / interrupt tests (POSIX `sleep`
+// is unavailable or unreliable under cmd.exe on some Windows dev machines).
+const LONG_RUNNING_COMMAND = 'node -e "setTimeout(()=>{},5000)"';
+
 // ---------------------------------------------------------------------------
 // shell.ts (from batch2)
 // ---------------------------------------------------------------------------
@@ -151,7 +155,7 @@ describe("runShell", () => {
   });
 
   it("times out a long-running command and kills it", async () => {
-    const result = await runShell("sleep 5", {
+    const result = await runShell(LONG_RUNNING_COMMAND, {
       cwd,
       timeoutMs: 100,
       outputLimit: BIG_LIMIT,
@@ -164,7 +168,7 @@ describe("runShell", () => {
 
   it("interrupts a running command when the signal aborts mid-flight", async () => {
     const controller = new AbortController();
-    const promise = runShell("sleep 5", {
+    const promise = runShell(LONG_RUNNING_COMMAND, {
       cwd,
       timeoutMs: 10_000,
       outputLimit: BIG_LIMIT,
@@ -190,7 +194,7 @@ describe("runShell", () => {
   });
 
   it("returns exitCode -1 when the close code is null (killed by timeout)", async () => {
-    const result = await runShell("sleep 5", {
+    const result = await runShell(LONG_RUNNING_COMMAND, {
       cwd,
       timeoutMs: 50,
       outputLimit: BIG_LIMIT,


### PR DESCRIPTION
## 关联 Issue

Closes #74

## 变更类型（勾选所有适用项）

- [ ] feat 新功能
- [ ] fix bug 修复
- [ ] docs 文档
- [ ] refactor 重构（无行为变更）
- [x] test 仅测试
- [ ] chore 构建 / 脚手架 / CI
- [ ] perf 性能优化

## 影响范围

- [ ] 改动了 `packages/protocol/`（跨边界协议，需要同步 SDK）
- [ ] 改动了 `packages/core/` 的公开 API
- [ ] 改动了 `src/gateway/`（session authority 行为变更）
- [ ] 改动了分层依赖（同步更新了 `AGENTS.md` 与 `.dependency-cruiser.cjs`）
- [x] 仅 docs / 注释 / 测试

## 变更说明（why，而非 what）

Windows 贡献者在未开启 Developer Mode 时运行 `pnpm check` 会失败 13 个测试（symlink `EPERM` + `sleep` 在 cmd 下不可靠），与 CONTRIBUTING 要求的 pre-push 全量检查冲突。本 PR 对齐 `docs/TESTING.md` 与 `file-tools.test.ts` 既有做法：symlink 用例 `skipIf(isWindows)`，timeout 用例改用跨平台 `node -e setTimeout` 命令。

## 测试计划

- [x] 单测：`pnpm test`（Windows 本地全绿）
- [x] 全量：`pnpm check`（Windows 本地全绿）
- [x] CI：ubuntu / windows / macos matrix

## 自检清单

- [x] 本地 `pnpm check` 已通过（lint / dep-guard / deadcode / tsc / format / test）
- [x] 新加文件配套加了 `.test.ts`（或在 PR 描述中说明豁免理由）
- [x] 平台相关代码用了 `vi.skipIf` / `describe.runIf`，未硬编码 platform 判断
- [x] 新增被覆盖统计的模块已同步加入 `vitest.config.ts` 的 `coverage.include`
- [x] 不包含二进制、构建产物、密钥
- [x] 未使用 `--no-verify` 绕过钩子
